### PR TITLE
Change minimum iOS requirement to 10.0

### DIFF
--- a/RWFramework/RWFramework/Playlist/AudioTrack.swift
+++ b/RWFramework/RWFramework/Playlist/AudioTrack.swift
@@ -251,19 +251,16 @@ private class TimedTrackState: TrackState {
         timer?.invalidate()
         timeLeft -= Date().timeIntervalSince(lastResume)
     }
-    @available(iOS 10.0, *)
+    
     func setupTimer() -> Timer {
         return Timer.scheduledTimer(withTimeInterval: timeLeft, repeats: false) { _ in
             self.goToNextState()
         }
     }
+
     func resume() {
         lastResume = Date()
-        if #available(iOS 10.0, *) {
-            timer = setupTimer()
-        } else {
-            // Fallback on earlier versions
-        }
+        timer = setupTimer()
     }
 }
 
@@ -314,7 +311,6 @@ private class FadingIn: TimedTrackState {
         super.init(duration: fadeInDur)
     }
     
-    @available(iOS 10.0, *)
     override func setupTimer() -> Timer {
         return Timer.scheduledTimer(
             withTimeInterval: FadingIn.updateInterval,
@@ -414,7 +410,6 @@ private class FadingOut: TimedTrackState {
         super.init(duration: duration)
     }
     
-    @available(iOS 10.0, *)
     override func setupTimer() -> Timer {
         return Timer.scheduledTimer(
             withTimeInterval: FadingOut.updateInterval,
@@ -457,7 +452,6 @@ private class WaitingForAsset: TimedTrackState {
         super.init(duration: 0)
     }
     
-    @available(iOS 10.0, *)
     override func setupTimer() -> Timer {
         return Timer.scheduledTimer(
             withTimeInterval: WaitingForAsset.updateInterval,

--- a/RWFramework/RWFramework/Playlist/Speaker.swift
+++ b/RWFramework/RWFramework/Playlist/Speaker.swift
@@ -116,26 +116,22 @@ extension Speaker {
         
         fadeTimer?.invalidate()
         if let player = self.player {
-            if #available(iOS 10.0, *) {
-                let totalDiff = vol - player.volume
-                let delta: Float = 0.075
-                fadeTimer = Timer.scheduledTimer(withTimeInterval: Double(delta), repeats: true) { timer in
-                    let currDiff = vol - player.volume
-                    if currDiff.sign != totalDiff.sign || abs(currDiff) < 0.05 {
-                        // we went just enough or too far
-                        player.volume = vol
-                        
-                        if vol < 0.05 {
-                            // we can't hear it anymore, so pause it.
-                            player.pause()
-                        }
-                        timer.invalidate()
-                    } else {
-                        player.volume += totalDiff * delta / Speaker.fadeDuration
+            let totalDiff = vol - player.volume
+            let delta: Float = 0.075
+            fadeTimer = Timer.scheduledTimer(withTimeInterval: Double(delta), repeats: true) { timer in
+                let currDiff = vol - player.volume
+                if currDiff.sign != totalDiff.sign || abs(currDiff) < 0.05 {
+                    // we went just enough or too far
+                    player.volume = vol
+                    
+                    if vol < 0.05 {
+                        // we can't hear it anymore, so pause it.
+                        player.pause()
                     }
+                    timer.invalidate()
+                } else {
+                    player.volume += totalDiff * delta / Speaker.fadeDuration
                 }
-            } else {
-                // Fallback on earlier versions
             }
         }
         

--- a/Roundware.podspec
+++ b/Roundware.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Roundware'
-  s.version          = '0.1.1'
+  s.version          = '0.2.0'
   s.summary          = 'Audio framework'
 
 # This description is used to generate tags and improve search results.
@@ -34,14 +34,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '10.0'
   s.swift_version = "4.2"
-  
-  # s.resource_bundles = {
-  #   'Roundware' => ['Roundware/Assets/*.png']
-  # }
 
-  # s.public_header_files = 'Pod/Classes/**/*.h'
-  # s.frameworks = 'UIKit', 'MapKit'
-  # s.dependency 'AFNetworking', '~> 2.3'
   s.frameworks = 'AVFoundation', 'SceneKit', 'SpriteKit'
 
   s.dependency "PromisesSwift", "~> 1.2.3"


### PR DESCRIPTION
This facilitates the usage of timers with closure arguments rather than having to use bound `@objc` methods.