### PR TITLE
Introduce passive acceptance for asset filters

### DIFF
--- a/RWFramework/RWFramework/Playlist/AssetFilter.swift
+++ b/RWFramework/RWFramework/Playlist/AssetFilter.swift
@@ -81,7 +81,7 @@ struct AnyTagsFilter: AssetFilter {
     func keep(_ asset: Asset, playlist: Playlist, track: AudioTrack) -> AssetPriority {
         // List of tag_ids to listen for.
         guard let listenTagIDs = RWFramework.sharedInstance.getSubmittableListenTagIDsSet()
-            else { return .passiveDiscard }
+            else { return .lowest }
 
         let matches = asset.tags.contains { assetTag in
             listenTagIDs.contains(assetTag)
@@ -95,7 +95,7 @@ struct AllTagsFilter: AssetFilter {
     func keep(_ asset: Asset, playlist: Playlist, track: AudioTrack) -> AssetPriority {
         // List of tag_ids to listen for.
         guard let listenTagIDs = RWFramework.sharedInstance.getSubmittableListenTagIDsSet()
-            else { return .passiveDiscard }
+            else { return .lowest }
 
         let matches = asset.tags.allSatisfy { assetTag in
             listenTagIDs.contains(assetTag)
@@ -109,7 +109,7 @@ struct TrackTagsFilter: AssetFilter {
     func keep(_ asset: Asset, playlist: Playlist, track: AudioTrack) -> AssetPriority {
         guard let trackTags = track.tags,
               trackTags.count != 0
-            else { return .passiveDiscard }
+            else { return .lowest }
         
         let matches = asset.tags.contains { assetTag in
             trackTags.contains(assetTag)

--- a/RWFramework/RWFramework/Playlist/AssetFilter.swift
+++ b/RWFramework/RWFramework/Playlist/AssetFilter.swift
@@ -45,7 +45,6 @@ struct AnyAssetFilters: AssetFilter {
         let ranks = filters.lazy
             .map { $0.keep(asset, playlist: playlist, track: track) }
         return ranks.first { $0 != .discard && $0 != .neutral }
-            ?? ranks.first { $0 != .discard }
             ?? .discard
     }
 }
@@ -73,7 +72,7 @@ struct AllAssetFilters: AssetFilter {
         } else {
             // Otherwise, simply use the first returned priority
             // Ideally the first that isn't .neutral
-            return ranks.first { $0 != .neutral } ?? ranks.first ?? .normal
+            return ranks.first { $0 != .neutral } ?? ranks.first!
         }
     }
 }

--- a/RWFramework/RWFramework/Playlist/Playlist.swift
+++ b/RWFramework/RWFramework/Playlist/Playlist.swift
@@ -176,11 +176,11 @@ extension Playlist {
         let filteredAssets = self.allAssets.lazy.map { asset in
             (asset, self.filters.keep(asset, playlist: self, track: track))
         }.filter { (asset, rank) in
-            rank != .discard && rank != .passiveDiscard
+            rank != .discard
         }
             
         let sortedAssets = filteredAssets.sorted { a, b in
-            a.1.rawValue <= b.1.rawValue
+            a.1.rawValue >= b.1.rawValue
         }.sorted { a, b in
             // play less played assets first
             let dataA = userAssetData[a.0.id]

--- a/RWFramework/RWFramework/Playlist/Playlist.swift
+++ b/RWFramework/RWFramework/Playlist/Playlist.swift
@@ -176,8 +176,10 @@ extension Playlist {
         let filteredAssets = self.allAssets.lazy.map { asset in
             (asset, self.filters.keep(asset, playlist: self, track: track))
         }.filter { (asset, rank) in
-            rank != .discard
-        }.sorted { a, b in
+            rank != .discard && rank != .passiveDiscard
+        }
+            
+        let sortedAssets = filteredAssets.sorted { a, b in
             a.1.rawValue <= b.1.rawValue
         }.sorted { a, b in
             // play less played assets first
@@ -192,19 +194,20 @@ extension Playlist {
             }
         }.map { (asset, rank) in asset }
         
-        print("\(filteredAssets.count) filtered assets")
+        print("\(sortedAssets.count) filtered assets")
         
-        let next = filteredAssets.first
+        let next = sortedAssets.first
         if let next = next {
             var playCount = 1
             if let prevEntry = userAssetData[next.id] {
                 playCount += prevEntry.playCount
-        }
+            }
+            
             userAssetData.updateValue(
                 UserAssetData(lastListen: Date(), playCount: playCount),
                 forKey: next.id
             )
-        print("picking asset: \(next)")
+            print("picking asset: \(next)")
         }
         return next
     }

--- a/RWFramework/RWFramework/Playlist/TimedAsset.swift
+++ b/RWFramework/RWFramework/Playlist/TimedAsset.swift
@@ -20,7 +20,7 @@ public class TimedAssetFilter: AssetFilter {
             ]).then { data in
                 self.timedAssets = data
             }
-            return .passiveDiscard
+            return .neutral
         } else if timedAssets!.isEmpty {
             return .discard
         }

--- a/RWFramework/RWFramework/Playlist/TimedAsset.swift
+++ b/RWFramework/RWFramework/Playlist/TimedAsset.swift
@@ -20,7 +20,7 @@ public class TimedAssetFilter: AssetFilter {
             ]).then { data in
                 self.timedAssets = data
             }
-            return .discard
+            return .passiveDiscard
         } else if timedAssets!.isEmpty {
             return .discard
         }


### PR DESCRIPTION
The `AssetPriority.neutral` option is added to allow an `AssetFilter` to passively accept an asset, but have that decision be overridden by any sibling filter, either by fully discarding or accepting, if their results are combined by an `AllAssetFilter` (`AND`) or `AnyAssetFilter` (`OR`).
Potential name options:
- `.neutral`
- `.passiveAccept`
- `.unknown`
- `.maybeAccept`