### PR TITLE
Use intermediate LoadingState to prevent loops

### DIFF
--- a/RWFramework/RWFramework/Playlist/AudioTrack.swift
+++ b/RWFramework/RWFramework/Playlist/AudioTrack.swift
@@ -84,16 +84,14 @@ extension AudioTrack {
         player.position = assetLoc.toAudioPoint(relativeTo: params.location)
     }
     
-    func updateParams(_ params: StreamParams) -> Promise<Void> {
-        return Promise {
-            // Pan the audio based on user location relative to the current asset
-            if let assetLoc = self.currentAsset?.location {
-                self.setDynamicPan(at: assetLoc, params)
-            }
-            // Change in parameters may make more assets available
-            if self.state is WaitingForAsset {
-                self.fadeInNextAsset()
-            }
+    func updateParams(_ params: StreamParams) {
+        // Pan the audio based on user location relative to the current asset
+        if let assetLoc = self.currentAsset?.location {
+            self.setDynamicPan(at: assetLoc, params)
+        }
+        // Change in parameters may make more assets available
+        if self.state is WaitingForAsset {
+            self.fadeInNextAsset()
         }
     }
     

--- a/RWFramework/RWFramework/Playlist/AudioTrack.swift
+++ b/RWFramework/RWFramework/Playlist/AudioTrack.swift
@@ -85,7 +85,7 @@ extension AudioTrack {
     }
     
     func updateParams(_ params: StreamParams) -> Promise<Void> {
-        return Promise { 
+        return Promise {
             // Pan the audio based on user location relative to the current asset
             if let assetLoc = self.currentAsset?.location {
                 self.setDynamicPan(at: assetLoc, params)
@@ -148,8 +148,8 @@ extension AudioTrack {
             player.scheduleFile(file, at: nil)
         }
 
-        if let params = self.playlist?.currentParams {
-            self.updateParams(params)
+        if let params = self.playlist?.currentParams, let loc = currentAsset?.location {
+            self.setDynamicPan(at: loc, params)
         }
     }
     

--- a/RWFramework/RWFramework/Playlist/AudioTrack.swift
+++ b/RWFramework/RWFramework/Playlist/AudioTrack.swift
@@ -158,6 +158,8 @@ extension AudioTrack {
     }
     
     func resume() {
+        // The first time we hit play, consider whether the track
+        // is configured to start with silence or an asset.
         if let state = state {
             state.resume()
         } else if self.startWithSilence {

--- a/RWFramework/RWFramework/Playlist/Playlist.swift
+++ b/RWFramework/RWFramework/Playlist/Playlist.swift
@@ -218,7 +218,9 @@ extension Playlist {
         if let tracks = self.tracks, let params = self.currentParams {
             do {
                 // update all tracks in parallel, in case they need to load a new track
-                _ = try await(all(tracks.map { $0.updateParams(params) }))
+                _ = try await(all(tracks.map { t in
+                    Promise { t.updateParams(params) }
+                }))
             } catch {
                 print(error)
             }

--- a/RWFramework/RWFramework/Playlist/Playlist.swift
+++ b/RWFramework/RWFramework/Playlist/Playlist.swift
@@ -180,7 +180,7 @@ extension Playlist {
         }.filter { (asset, rank) in
             rank != .discard
         }
-            
+        
         let sortedAssets = filteredAssets.sorted { a, b in
             a.1.rawValue >= b.1.rawValue
         }.sorted { a, b in
@@ -216,8 +216,11 @@ extension Playlist {
     
     private func updateTrackParams() {
         if let tracks = self.tracks, let params = self.currentParams {
-            for track in tracks {
-                track.updateParams(params)
+            do {
+                // update all tracks in parallel, in case they need to load a new track
+                _ = try await(all(tracks.map { $0.updateParams(params) }))
+            } catch {
+                print(error)
             }
         }
     }

--- a/RWFramework/RWFramework/Playlist/Playlist.swift
+++ b/RWFramework/RWFramework/Playlist/Playlist.swift
@@ -416,7 +416,7 @@ extension Playlist {
     func skip() {
         // Fade out the currently playing assets on all tracks.
         tracks?.forEach {
-            $0.playNext(premature: true)
+            $0.playNext()
         }
     }
 }


### PR DESCRIPTION
Add a new state to `AudioTrack`: `LoadingState`. This is used when the track is downloading an asset, so that if any parameter updates happen during this time, we don't try to start downloading another new asset.