### PR TITLE
Allow resuming assets during dead-air

### DIFF
--- a/RWFramework/RWFramework/Playlist/AudioTrack.swift
+++ b/RWFramework/RWFramework/Playlist/AudioTrack.swift
@@ -201,30 +201,30 @@ extension AudioTrack {
     /// - returns: if an asset has been chosen and started
     func fadeInNextAsset() {
         if let next = self.playlist?.next(forTrack: self) {
-        previousAsset = currentAsset
-        currentAsset = next
-        
-        let activeRegionLength = Double(next.activeRegion.upperBound - next.activeRegion.lowerBound)
-        let minDuration = min(Double(self.duration.lowerBound), activeRegionLength)
-        let maxDuration = min(Double(self.duration.upperBound), activeRegionLength)
-        let duration = (minDuration...maxDuration).random()
-        let latestStart = Double(next.activeRegion.upperBound) - duration
-        let start = (Double(next.activeRegion.lowerBound)...latestStart).random()
-        
-        // load the asset file
-        do {
-            try loadNextAsset(start: start, for: duration)
-        } catch {
-            print(error)
-            playNext()
-            return
-        }
-        
-        transition(to: FadingIn(
-            track: self,
-            asset: next,
-            assetDuration: duration
-        ))
+            previousAsset = currentAsset
+            currentAsset = next
+            
+            let activeRegionLength = Double(next.activeRegion.upperBound - next.activeRegion.lowerBound)
+            let minDuration = min(Double(self.duration.lowerBound), activeRegionLength)
+            let maxDuration = min(Double(self.duration.upperBound), activeRegionLength)
+            let duration = (minDuration...maxDuration).random()
+            let latestStart = Double(next.activeRegion.upperBound) - duration
+            let start = (Double(next.activeRegion.lowerBound)...latestStart).random()
+            
+            // load the asset file
+            do {
+                try loadNextAsset(start: start, for: duration)
+            } catch {
+                print(error)
+                playNext()
+                return
+            }
+            
+            transition(to: FadingIn(
+                track: self,
+                asset: next,
+                assetDuration: duration
+            ))
         } else if !(self.state is WaitingForAsset) {
             transition(to: WaitingForAsset(track: self))
         }

--- a/RWFramework/RWFramework/Playlist/AudioTrack.swift
+++ b/RWFramework/RWFramework/Playlist/AudioTrack.swift
@@ -333,10 +333,10 @@ private class ResumableDeadAir: TimedTrackState {
     private let asset: Asset
     private let remainingDurationOfAsset: Double
 
-    init(track: AudioTrack, asset: Asset, remainingTime: Double) {
+    init(track: AudioTrack, asset: Asset, remainingAssetTime: Double) {
         self.track = track
         self.asset = asset
-        self.remainingDurationOfAsset = remainingTime
+        self.remainingDurationOfAsset = remainingAssetTime
         super.init(duration: Double(track.deadAir.upperBound))
     }
 
@@ -476,7 +476,7 @@ private class PlayingAsset: TimedTrackState {
                 track: track,
                 asset: asset,
                 duration: fadeOutDuration,
-                remainingTime: timeLeft + fadeOutDuration
+                remainingAssetTime: timeLeft
             ))
         }
     }
@@ -488,8 +488,8 @@ private class FadingOut: TimedTrackState {
     
     private let track: AudioTrack
     private let asset: Asset
-    private let remainingTime: Double?
     private let followedByDeadAir: Bool
+    private let remainingAssetTime: Double?
 
     override var canSkip: Bool { return false }
     
@@ -498,12 +498,12 @@ private class FadingOut: TimedTrackState {
         asset: Asset,
         duration: Double,
         followedByDeadAir: Bool = true,
-        remainingTime: Double? = nil
+        remainingAssetTime: Double? = nil
     ) {
         self.track = track
         self.asset = asset
-        self.remainingTime = remainingTime
         self.followedByDeadAir = followedByDeadAir
+        self.remainingAssetTime = remainingAssetTime
         super.init(duration: duration)
     }
     
@@ -533,11 +533,11 @@ private class FadingOut: TimedTrackState {
     
     override func goToNextState() {
         if (followedByDeadAir) {
-            if let remainingTime = self.remainingTime {
+            if let remainingTime = self.remainingAssetTime {
                 track.transition(to: ResumableDeadAir(
                     track: track,
                     asset: asset,
-                    remainingTime: remainingTime
+                    remainingAssetTime: remainingTime
                 ))
             } else {
                 track.transition(to: DeadAir(track: track))

--- a/RWFramework/RWFramework/Playlist/Playlist.swift
+++ b/RWFramework/RWFramework/Playlist/Playlist.swift
@@ -209,6 +209,10 @@ extension Playlist {
         }
         return next
     }
+
+    func passesFilters(_ asset: Asset, forTrack track: AudioTrack) -> Bool {
+        return self.filters.keep(asset, playlist: self, track: track)
+    }
     
     private func updateTrackParams() {
         if let tracks = self.tracks, let params = self.currentParams {

--- a/RWFramework/RWFramework/Playlist/Playlist.swift
+++ b/RWFramework/RWFramework/Playlist/Playlist.swift
@@ -205,6 +205,8 @@ extension Playlist {
             (asset, self.filters.keep(asset, playlist: self, track: track))
         }.filter { (asset, rank) in
             rank != .discard
+                // don't pick anything currently playing on another track
+                && !self.currentlyPlayingAssets.contains { $0.id == asset.id }
         }
         
         let sortedAssets = filteredAssets.sorted { a, b in
@@ -226,18 +228,21 @@ extension Playlist {
         
         let next = sortedAssets.first
         if let next = next {
-            var playCount = 1
-            if let prevEntry = userAssetData[next.id] {
-                playCount += prevEntry.playCount
-            }
-            
-            userAssetData.updateValue(
-                UserAssetData(lastListen: Date(), playCount: playCount),
-                forKey: next.id
-            )
             print("picking asset: \(next)")
         }
         return next
+    }
+
+    func recordFinishedPlaying(asset: Asset) {
+        var playCount = 1
+        if let prevEntry = userAssetData[asset.id] {
+            playCount += prevEntry.playCount
+        }
+        
+        userAssetData.updateValue(
+            UserAssetData(lastListen: Date(), playCount: playCount),
+            forKey: asset.id
+        )
     }
 
     func passesFilters(_ asset: Asset, forTrack track: AudioTrack) -> Bool {


### PR DESCRIPTION
This PR adds a few features behind the server field `track.asset_geo_fadeout`:
- Fades out assets once you leave their range or otherwise filter them out.
- Introduces the `ResumableDeadAir: TrackState`, which lets that track go into silence but have the last asset resume if it suddenly passes the filters again upon parameter update.

This covers updates to location, range, angle, tags.